### PR TITLE
Add modulate support to alter the color

### DIFF
--- a/transition.gdshader
+++ b/transition.gdshader
@@ -98,6 +98,7 @@ float get_local_progress(vec2 grid) {
     float offset = dot(cell, pretty_bias);
     return progress - offset;
 }
+
 void vertex() {
 	modulate = COLOR;
 }
@@ -152,6 +153,7 @@ void fragment() {
 		float separation_y = smoothstep(smooth_edges.x, smooth_edges.y, abs(uv.y));
 		transition_progress = max(separation_x, separation_y);
 	}
+	
 	alpha = invert ? 1.0 - transition_progress : transition_progress;
 	alpha = use_sprite_alpha ? min(COLOR.a, alpha) : alpha;
 


### PR DESCRIPTION
With this change, the Modulate property can alter the color of the texture. 

<img width="1344" height="498" alt="image" src="https://github.com/user-attachments/assets/1be516fc-b01f-4bcb-8d4b-1f7986d40ce9" />

As a bonus, this also allows you to use a ColorRect for the transition:

<img width="1113" height="642" alt="image" src="https://github.com/user-attachments/assets/860d8016-1340-4417-96f5-47306305638e" />
