### PR TITLE
Transition Texture no longer switches places with the base texture

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ _Hint: If `transition_texture` is not set, the shader blends between `COLOR` and
 
 `transition_texture` (`sampler2D`)
 
-The texture that will be transitioned to/from when `use_transition_texture` is set to `true`.
+The texture that will be transitioned to when `use_transition_texture` is set to `true`.
 
 _Hint: Has no effect if `use_transition_texture` is `false`._
 

--- a/transition.gdshader
+++ b/transition.gdshader
@@ -160,7 +160,7 @@ void fragment() {
 	vec4 transition_color = texture(transition_texture, UV);
 
 	if (use_transition_texture) {
-		vec4 chosen_color = mix(COLOR, transition_color, alpha);
+		vec4 chosen_color = mix(transition_color, COLOR, alpha);
 		COLOR = chosen_color;
 	} else {
 		COLOR.a = alpha;


### PR DESCRIPTION
Transition Texture is now correctly set as the texture to transition to instead of swapping places with the base texture:
<img width="500" alt="transition texture working correctly" src="https://github.com/user-attachments/assets/692c89ee-39e5-4ab5-8ccf-6859574fc453" />
