### PR TITLE
feat: New property to position the transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Center Wipe**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 
 <img src="https://github.com/user-attachments/assets/79827e31-7be0-454d-bcf3-cfb5a43a3626" width="100" />
 
@@ -92,14 +92,14 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Grid Reveal**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (10.0, 10.0) - or any abs(x) > 0.0; abs(y) > 0.0;
 
 <img src="https://github.com/user-attachments/assets/a4b460e9-c43d-4d57-b656-631e5ea0f4e6" width="100" />
 
 **Staggered Grid Reveal**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (10.0, 10.0) - or any abs(x) > 0.0; abs(y) > 0.0;
 - `stagger`: (1.0, 0.0) or (0.0, 1.0)
 
@@ -108,7 +108,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Mixed Stagger Reveal**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (5.0, 5.0)
 - `stagger`: (1.0, 1.0)
 
@@ -116,14 +116,14 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Cross-shaped Transition (All corners wipe)**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `stagger`: (1.0, 1.0)
 
 <img src="https://github.com/user-attachments/assets/24819aeb-16a8-40f2-bfd3-e3434fd9d7a7" width="100" />
 
 **Diagonal Popping Squares**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (5.0, 5.0)
 - `progress_bias`: (10.0, 10.0)
 
@@ -131,7 +131,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Step Wipe**
 - `transition_type`: Basic
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (5.0, 0.0) or (0.0, 5.0)
 - `progress_bias`: (5.0, 0.0) or (0.0, 5.0)
 
@@ -140,14 +140,14 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Mask Reveal**
 - `transition_type`: Mask
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `mask_texture`: Any black & white texture
 
 <img src="https://github.com/user-attachments/assets/645de630-ee98-428e-8b0d-221f6e57446e" width="100" />
 
 **Alternating Mask Grid**
 - `transition_type`: Mask
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (5.0, 5.0)
 - `mask_texture`: Any black & white texture
 - `flip_frequency`: (1.0, 2.0)
@@ -156,7 +156,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Iris Transition**
 - `transition_type`: Shape
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `edges`: 64
 - `shape_feather`: 0.1
 
@@ -164,7 +164,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Spike Transition**
 - `transition_type`: Shape
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `edges`: 3
 - `grid_size` & `rotation_angle`: `(0.5, y) & 0.0` or `(x, -0.5) & 90.0`
 
@@ -173,7 +173,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Scratch Lines Reveal**
 - `transition_type`: Shape
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (50.0, 5.0)
 - `edges`: 3
 - `flip_frequency`: (2.0, 1.0)
@@ -182,7 +182,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 
 **Overlapping Diamonds**
 - `transition_type`: Shape
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (0.5, 50.0) or (50.0, 0.5)
 - `edges`: 3
 - `shape_feather`: 0.0
@@ -202,7 +202,7 @@ _Hint: Each recipe contains only the most basic 'ingredients', without which the
 **Center-Clock Transition**
 - `transition_type`: Clock
 - `invert`: true
-- `from_center`: true
+- `position`: (0.5, 0.5)
 - `grid_size`: (1.0, 1.0) or (-1.0, -1.0) or (-1.0, 1.0) or (1.0, -1.0)
 
 <img src="https://github.com/user-attachments/assets/bdc012f3-7519-4f3c-bb38-098058a9b737" width="80" />
@@ -297,11 +297,14 @@ Reverses the logical direction of the transition's progression. For example, a t
 
 ---
 
-`from_center` (`bool`, default: `false`)
+`position` (`vec2`, default: `(0.0, 0,0)`)
 
-When `false`, the origin is typically one of the edges or corners, depending on `grid_size`, `stagger` and `rotation_angle`.
-
-When `true`, the transition's origin point is considered the center of the `CanvasItem`'s local coordinate system. 
+Specifies the position in each grid cell (see `grid_size` parameter) from where the transition starts.
+- `(0.0, 0.0)` - top left corner
+- `(1.0, 0.0)` - top right corner
+- `(0,0, 1.0)` - bottom left corner
+- `(1.0, 1.0)` - bottom right corner
+- `(0.5, 0.5)` - center
 
 ---
 

--- a/transition.gdshader
+++ b/transition.gdshader
@@ -6,7 +6,7 @@ uniform sampler2D transition_texture;
 uniform int transition_type: hint_enum("Basic", "Mask", "Shape", "Clock") = 0;
 
 group_uniforms positioning;
-uniform vec2 position = vec2(0,0)
+uniform vec2 position = vec2(0,0);
 uniform bool invert = false;
 uniform vec2 grid_size = vec2(1.0, 1.0);
 uniform float rotation_angle = 0.0;
@@ -108,7 +108,7 @@ void fragment() {
 	vec2 offset_uv = grid + get_stagger_offset(grid);
 	vec2 grid_flipped_uv = get_grid_flip(offset_uv);
 	vec2 tiled_uv = fract(grid_flipped_uv);
-	vec2 uv = tiled_uv - position;
+	vec2 uv = (tiled_uv - position) * 2.0;
 	uv = rotate(uv, radians(rotation_angle));
 
 	float local_progress = get_local_progress(grid);

--- a/transition.gdshader
+++ b/transition.gdshader
@@ -6,8 +6,8 @@ uniform sampler2D transition_texture;
 uniform int transition_type: hint_enum("Basic", "Mask", "Shape", "Clock") = 0;
 
 group_uniforms positioning;
+uniform vec2 position = vec2(0,0)
 uniform bool invert = false;
-uniform bool from_center = false;
 uniform vec2 grid_size = vec2(1.0, 1.0);
 uniform float rotation_angle = 0.0;
 
@@ -108,7 +108,7 @@ void fragment() {
 	vec2 offset_uv = grid + get_stagger_offset(grid);
 	vec2 grid_flipped_uv = get_grid_flip(offset_uv);
 	vec2 tiled_uv = fract(grid_flipped_uv);
-	vec2 uv = from_center ? 2.0 * tiled_uv - 1.0 : tiled_uv;
+	vec2 uv = tiled_uv - position;
 	uv = rotate(uv, radians(rotation_angle));
 
 	float local_progress = get_local_progress(grid);
@@ -153,7 +153,7 @@ void fragment() {
 		float separation_y = smoothstep(smooth_edges.x, smooth_edges.y, abs(uv.y));
 		transition_progress = max(separation_x, separation_y);
 	}
-	
+
 	alpha = invert ? 1.0 - transition_progress : transition_progress;
 	alpha = use_sprite_alpha ? min(COLOR.a, alpha) : alpha;
 


### PR DESCRIPTION
This new property allow to custom the position where the transition happens. A value of (0.5 , 0.5) will set it to the center, as the previous "From Center" checkbox allowed.

![Godot_H47dFgB4Jy](https://github.com/user-attachments/assets/2b6b8e1b-fec6-4108-a683-d08c47775472)
