### PR TITLE
Add cumulative stagger

### DIFF
--- a/transition.gdshader
+++ b/transition.gdshader
@@ -13,6 +13,7 @@ uniform float rotation_angle = 0.0;
 
 group_uniforms positioning.stagger;
 uniform vec2 stagger = vec2(0.0, 0.0);
+uniform vec2 cumulative_stagger = vec2(0, 0);
 uniform ivec2 stagger_frequency = ivec2(2, 2);
 uniform ivec2 flip_frequency = ivec2(1, 1);
 
@@ -61,8 +62,8 @@ vec2 get_stagger_offset(vec2 grid) {
 	float offset_col = mod(cells.x, float(stagger_frequency.y)) == 0.0 ? 0.5 : 0.0;
 
 	return vec2(
-		offset_row * stagger.x,
-		offset_col * stagger.y
+		offset_row * (stagger.x + cells.y * cumulative_stagger.x),
+		offset_col * (stagger.y + cells.x * cumulative_stagger.y)
 	);
 }
 


### PR DESCRIPTION
Looks like this:
<img width="386" height="391" alt="image" src="https://github.com/user-attachments/assets/6560c052-705e-4bde-be2d-eba4ca8b2c89" />

Allows you to make staircased stagger effects on top of the current behavior. Very simple, but also effective change. I believe this can be useful in many ways when combined with everything else that we already have.

---
Also add this to the animations that can be made:
stagger (1, 1), clock, flip frequency (2, 2), 2 clock sectors, position (0.5, 0.5)
<img width="369" height="371" alt="image" src="https://github.com/user-attachments/assets/02eab2f2-3ceb-4705-9abb-1512ce860960" />
<img width="359" height="353" alt="image" src="https://github.com/user-attachments/assets/f4a43082-0656-49ee-8970-a91a63bbd783" />

cumulative stagger animated from (1, 0) to (3, 0), stagger frequency (1, 1), grid size (4, 6), position (0.5, 0.5)
<img width="346" height="352" alt="image" src="https://github.com/user-attachments/assets/2880993e-2c64-48dc-a8bc-f8fd6ab8a116" />
<img width="331" height="331" alt="image" src="https://github.com/user-attachments/assets/6d67979a-445e-49d0-ba0b-f133682627b4" />
(it goes sideways because of cumulative stagger being animated)